### PR TITLE
Added autoHighlight option

### DIFF
--- a/src/jquery.better-autocomplete.js
+++ b/src/jquery.better-autocomplete.js
@@ -366,13 +366,21 @@ var BetterAutocomplete = function($input, resource, options, callbacks) {
   /**
    * Select the current highlighted element, if any.
    */
-  var select = function() {
+  var selectHighlighted = function(autoSelection) {
+    var autoSelection = autoSelection || false;
     var $result = $('.result', $results).eq(getHighlighted());
     if (!$result.length) {
       return; // No selectable element
     }
     var result = $result.data('result');
-    callbacks.select(result, $input);
+    callbacks.select(result, $input, autoSelection);
+  };
+
+  /**
+   * Select the current highlighted element, then redraw.
+   */
+  var select = function() {
+    selectHighlighted();
     // Redraw again, if the callback changed focus or content
     reprocess();
   };

--- a/src/jquery.better-autocomplete.js
+++ b/src/jquery.better-autocomplete.js
@@ -191,8 +191,20 @@ var BetterAutocomplete = function($input, resource, options, callbacks) {
 
   inputEvents.keydown = function(event) {
     var index = getHighlighted();
+    var hasResults = (($results.children().length && index < 0) || index >= 0);
+
+    // no highlight but, they pressed [enter]
+    if (hasResults &&
+        event.keyCode == 13 &&
+        index < 0) {
+        // assume the user wants to perform the search without using
+        // any of the suggestions
+        this.form.submit();
+        return false;
+    }
+
     // If an arrow key is pressed and a result is highlighted
-    if ($.inArray(event.keyCode, [38, 40]) >= 0 && index >= 0) {
+    if ($.inArray(event.keyCode, [38, 40]) >= 0 && hasResults) {
       var newIndex,
         size = $('.result', $results).length;
       switch (event.keyCode) {
@@ -445,7 +457,6 @@ var BetterAutocomplete = function($input, resource, options, callbacks) {
     else if (lastRenderedQuery !== query) {
       lastRenderedQuery = query;
       renderResults(cache[query]);
-      setHighlighted(0);
     }
     // Finally show/hide based on focus and emptiness
     if (($input.is(':focus') || focus) && !$results.is(':empty')) {

--- a/src/jquery.better-autocomplete.js
+++ b/src/jquery.better-autocomplete.js
@@ -176,7 +176,8 @@ var BetterAutocomplete = function($input, resource, options, callbacks) {
     crossOrigin: false,
     selectKeys: [9, 13], // [tab, enter]
     autoHighlight: false, // true, auto-highlight first result
-    autoSelect: true // Select the highlighted element automatically
+    autoSelect: true, // Select the highlighted element automatically
+    autoReprocess: false // Whether to reprocess or not after an item has been selected
   }, options);
 
   callbacks = $.extend({}, defaultCallbacks, callbacks);
@@ -431,12 +432,20 @@ var BetterAutocomplete = function($input, resource, options, callbacks) {
   function reprocess(event) {
     // Since this function can be called as not an event handler also, the event
     // variable doesn't always exist.
-    // If it does, check if we triggered the handler with an up or down key, and
-    // don't do anything if the autoSelect option is on.
-    if (options.autoSelect && event != undefined && event.type == 'keyup' &&
-       (event.keyCode == 38 || event.keyCode == 40)) {
-      return false;
+    if (event != undefined) {
+      // Don't do anything, if autoSelect is on, and up or down key has been pressed.
+      if (options.autoSelect && event.type == 'keyup' &&
+        (event.keyCode == 38 || event.keyCode == 40)) {
+        return false;
+      }
+      // If autoReprocess is off empty the result popoup, then don't do anything else
+      // if the key that has been pressed is a select key.
+      if (!options.autoReprocess && event.type == 'keyup' && isSelectKeyPressed(event)) {
+        $results.empty();
+        return false;
+      }
     }
+
     var query = callbacks.canonicalQuery($input.val(), options.caseSensitive);
     clearTimeout(timer);
     // Indicate that timer is inactive

--- a/src/jquery.better-autocomplete.js
+++ b/src/jquery.better-autocomplete.js
@@ -174,7 +174,8 @@ var BetterAutocomplete = function($input, resource, options, callbacks) {
     cacheLimit: isLocal ? 0 : 256, // Number of result objects
     remoteTimeout: 10000, // milliseconds
     crossOrigin: false,
-    selectKeys: [9, 13] // [tab, enter]
+    selectKeys: [9, 13], // [tab, enter]
+    autoHighlight: false, // true, auto-highlight first result
   }, options);
 
   callbacks = $.extend({}, defaultCallbacks, callbacks);
@@ -195,7 +196,8 @@ var BetterAutocomplete = function($input, resource, options, callbacks) {
 
     // no highlight but, they pressed [enter]
     if (hasResults &&
-        event.keyCode == 13 &&
+        !options.autoHighlight &&
+        event.keyCode === 13 &&
         index < 0) {
         // assume the user wants to perform the search without using
         // any of the suggestions
@@ -457,6 +459,9 @@ var BetterAutocomplete = function($input, resource, options, callbacks) {
     else if (lastRenderedQuery !== query) {
       lastRenderedQuery = query;
       renderResults(cache[query]);
+      if (options.autoHighlight) {
+          setHighlighted(0);
+      }
     }
     // Finally show/hide based on focus and emptiness
     if (($input.is(':focus') || focus) && !$results.is(':empty')) {

--- a/src/jquery.better-autocomplete.js
+++ b/src/jquery.better-autocomplete.js
@@ -175,7 +175,8 @@ var BetterAutocomplete = function($input, resource, options, callbacks) {
     remoteTimeout: 10000, // milliseconds
     crossOrigin: false,
     selectKeys: [9, 13], // [tab, enter]
-    autoHighlight: false // true, auto-highlight first result
+    autoHighlight: false, // true, auto-highlight first result
+    autoSelect: true // Select the highlighted element automatically
   }, options);
 
   callbacks = $.extend({}, defaultCallbacks, callbacks);
@@ -351,6 +352,9 @@ var BetterAutocomplete = function($input, resource, options, callbacks) {
       $results.scrollTop($scrollTo.position().top + $results.scrollTop() +
           $scrollTo.outerHeight() - $results.height());
     }
+    if (options.autoSelect) {
+      selectHighlighted(true);
+    }
   };
 
   /**
@@ -426,7 +430,15 @@ var BetterAutocomplete = function($input, resource, options, callbacks) {
    * Reprocess the contents of the input field, fetch data and redraw if
    * necessary.
    */
-  function reprocess() {
+  function reprocess(event) {
+    // Since this function can be called as not an event handler also, the event
+    // variable doesn't always exist.
+    // If it does, check if we triggered the handler with an up or down key, and
+    // don't do anything if the autoSelect option is on.
+    if (options.autoSelect && event != undefined && event.type == 'keyup' &&
+       (event.keyCode == 38 || event.keyCode == 40)) {
+      return false;
+    }
     var query = callbacks.canonicalQuery($input.val(), options.caseSensitive);
     clearTimeout(timer);
     // Indicate that timer is inactive
@@ -561,8 +573,12 @@ var defaultCallbacks = {
    *
    * @param {Object} $input
    *   The input DOM element, wrapped in jQuery.
+   *
+   * @param {Boolean} autoSelection
+   *   Whether the callback got fired by auto selection (up and down keys, when
+   *   this option is on).
    */
-  select: function(result, $input) {
+  select: function(result, $input, autoSelection) {
     $input.val(result.title);
   },
 

--- a/src/jquery.better-autocomplete.js
+++ b/src/jquery.better-autocomplete.js
@@ -175,7 +175,7 @@ var BetterAutocomplete = function($input, resource, options, callbacks) {
     remoteTimeout: 10000, // milliseconds
     crossOrigin: false,
     selectKeys: [9, 13], // [tab, enter]
-    autoHighlight: false, // true, auto-highlight first result
+    autoHighlight: false // true, auto-highlight first result
   }, options);
 
   callbacks = $.extend({}, defaultCallbacks, callbacks);
@@ -192,11 +192,9 @@ var BetterAutocomplete = function($input, resource, options, callbacks) {
 
   inputEvents.keydown = function(event) {
     var index = getHighlighted();
-    var hasResults = (($results.children().length && index < 0) || index >= 0);
 
     // no highlight but, they pressed [enter]
-    if (hasResults &&
-        !options.autoHighlight &&
+    if (!options.autoHighlight &&
         event.keyCode === 13 &&
         index < 0) {
         // assume the user wants to perform the search without using
@@ -205,6 +203,7 @@ var BetterAutocomplete = function($input, resource, options, callbacks) {
         return false;
     }
 
+    var hasResults = (($results.children().length && index < 0) || index >= 0);
     // If an arrow key is pressed and a result is highlighted
     if ($.inArray(event.keyCode, [38, 40]) >= 0 && hasResults) {
       var newIndex,

--- a/src/jquery.better-autocomplete.js
+++ b/src/jquery.better-autocomplete.js
@@ -222,9 +222,7 @@ var BetterAutocomplete = function($input, resource, options, callbacks) {
       return false;
     }
     // A select key has been pressed
-    else if ($.inArray(event.keyCode, options.selectKeys) >= 0 &&
-             !event.shiftKey && !event.ctrlKey && !event.altKey &&
-             !event.metaKey) {
+    else if (isSelectKeyPressed(event)) {
       select();
       return event.keyCode == 9; // Never cancel tab
     }
@@ -541,6 +539,20 @@ var BetterAutocomplete = function($input, resource, options, callbacks) {
       $result.insertAfter($target.length ? $target : $traverseFrom);
     });
   };
+
+  /**
+   * Determine whether a select key has been pressed.
+   *
+   * @param {eventObject} event
+   *    The Event object of a keyup/keydown/etc.
+   *
+   * @returns {Boolean}
+   *    true, if the key that has been pressed is a select key, false otherwise.
+   */
+  var isSelectKeyPressed = function(event) {
+    return $.inArray(event.keyCode, options.selectKeys) >= 0 && !event.shiftKey &&
+           !event.ctrlKey && !event.altKey && !event.metaKey;
+  }
 };
 
 /*


### PR DESCRIPTION
The user/dev now has the ability to disable auto-highlighting of the first result. Allowing the users to press [enter] to submit the field's value, rather than it selecting the first result, and submitting that instead. A better reflection of Google auto-complete, etc.
