### PR TITLE
Usability Enhancements

### DIFF
--- a/src/jquery.better-autocomplete.js
+++ b/src/jquery.better-autocomplete.js
@@ -419,11 +419,13 @@ var BetterAutocomplete = function($input, resource, options, callbacks) {
    * Select the current highlighted element, if any.
    */
   var select = function() {
-    var highlighted = getHighlightedIndex(),
-      result = getResultByIndex(highlighted);
-    callbacks.select(result, $input);
-    // Redraw again, if the callback changed focus or content
-    reprocess();
+    var highlighted = getHighlightedIndex();
+    if(highlighted >= 0){
+      var result = getResultByIndex(highlighted);
+      callbacks.select(result, $input);
+      // Redraw again, if the callback changed focus or content
+      reprocess();
+    }
   };
 
   /**

--- a/src/jquery.better-autocomplete.js
+++ b/src/jquery.better-autocomplete.js
@@ -211,7 +211,7 @@ var BetterAutocomplete = function($input, resource, options, callbacks) {
         size = $('.result', $results).length;
       switch (event.keyCode) {
       case 38: // Up arrow
-        newIndex = Math.max(0, index - 1);
+        newIndex = Math.max(-1, index - 1);
         break;
       case 40: // Down arrow
         newIndex = Math.min(size - 1, index + 1);

--- a/src/jquery.better-autocomplete.js
+++ b/src/jquery.better-autocomplete.js
@@ -226,7 +226,7 @@ var BetterAutocomplete = function($input, resource, options, callbacks) {
              !event.shiftKey && !event.ctrlKey && !event.altKey &&
              !event.metaKey) {
       select();
-      return event.keyCode == 9; // Never cancel tab
+      return event.keyCode == 9 || event.keyCode == 13; // Never cancel tab or enter
     }
   };
 


### PR DESCRIPTION
This pull request enhances usability of Better Autocomplete in three ways:
1. Allows the user to clear the selection by pressing &lt;up> when the top item is selected - 3fbb7a91
2. Prevents Better Autocomplete from stopping propogation of &lt;enter>, if &lt;enter> is a selectKey - 967a71bc
3. Prevents Better Autocomplete from selecting an item if a selectKey is pressed when no selection is made - a2f826ba
